### PR TITLE
Refactor repository gathering functions to simplify error handling an…

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -235,11 +235,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter, s *utils
 
 			if cmdFlags.ruleType == "all" || cmdFlags.ruleType == "repoOnly" {
 				zap.S().Infof("Gathering repositories specified in org %s to list rulesets for", sourceOrg)
-				allRepos, err := g.GatherRepositories(sourceOrg, repos)
-				if err != nil {
-					zap.S().Error("Error raised in gathering repos", zap.Error(err))
-					return err
-				}
+				allRepos := g.GatherRepositories(sourceOrg, repos)
 				allRepoRules, err := g.FetchRepoRulesets(sourceOrg, allRepos)
 				if err != nil {
 					zap.S().Error("Error raised in fetching repo ruleset data", zap.Error(err))

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -215,11 +215,7 @@ func runCmdList(owner string, repos []string, cmdFlags *cmdFlags, g *utils.APIGe
 
 		if cmdFlags.ruleType == "all" || cmdFlags.ruleType == "repoOnly" {
 			zap.S().Infof("Gathering repositories specified in org %s to list rulesets for", owner)
-			allRepos, err := g.GatherRepositories(owner, repos)
-			if err != nil {
-				zap.S().Error("Error raised in gathering repos", zap.Error(err))
-				return err
-			}
+			allRepos := g.GatherRepositories(owner, repos)
 			allRepoRules, err := g.FetchRepoRulesets(owner, allRepos)
 			if err != nil {
 				zap.S().Error("Error raised in fetching repo ruleset data", zap.Error(err))

--- a/internal/utils/exportruleset.go
+++ b/internal/utils/exportruleset.go
@@ -79,8 +79,10 @@ func ProcessConditions(ruleset data.RepoRuleset) data.ProcessedConditions {
 			PropertyInclude = ProcessProperties(ruleset.Conditions.RepositoryProperty.Include)
 			PropertyExclude = ProcessProperties(ruleset.Conditions.RepositoryProperty.Exclude)
 		}
-		includeRefNames = strings.Join(ruleset.Conditions.RefName.Include, ";")
-		excludeRefNames = strings.Join(ruleset.Conditions.RefName.Exclude, ";")
+		if ruleset.Conditions.RefName != nil {
+			includeRefNames = strings.Join(ruleset.Conditions.RefName.Include, ";")
+			excludeRefNames = strings.Join(ruleset.Conditions.RefName.Exclude, ";")
+		}
 	}
 	return data.ProcessedConditions{
 		IncludeNames:    includeNames,

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -169,7 +169,7 @@ func (g *APIGetter) FetchRepoRulesets(owner string, repos []data.RepoInfo) ([]da
 	return allRepoRules, nil
 }
 
-func (g *APIGetter) GatherRepositories(owner string, repos []string) ([]data.RepoInfo, error) {
+func (g *APIGetter) GatherRepositories(owner string, repos []string) []data.RepoInfo {
 	var allRepos []data.RepoInfo
 	var reposCursor *string
 
@@ -187,7 +187,7 @@ func (g *APIGetter) GatherRepositories(owner string, repos []string) ([]data.Rep
 			reposQuery, err := g.GetReposList(owner, reposCursor)
 			if err != nil {
 				zap.S().Error("Error raised in processing list of repos", zap.Error(err))
-				return nil, err
+				return allRepos
 			}
 			allRepos = append(allRepos, reposQuery.Organization.Repositories.Nodes...)
 			reposCursor = &reposQuery.Organization.Repositories.PageInfo.EndCursor
@@ -196,7 +196,7 @@ func (g *APIGetter) GatherRepositories(owner string, repos []string) ([]data.Rep
 			}
 		}
 	}
-	return allRepos, nil
+	return allRepos
 }
 func (g *APIGetter) GetAnApp(appSlug string) (*data.AppInfo, error) {
 	url := fmt.Sprintf("apps/%s", appSlug)


### PR DESCRIPTION
This pull request simplifies error handling in the `GatherRepositories` method and ensures proper handling of `RefName` conditions in ruleset processing. The key changes include removing error returns from `GatherRepositories` and adding a nil check for `RefName` conditions.

### Error handling simplification:
* [`internal/utils/general.go`](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L172-R172): Removed error return from the `GatherRepositories` method and updated its call sites to handle the absence of errors. This includes changes to ensure the method always returns a list of repositories, even if partial results are retrieved. [[1]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L172-R172) [[2]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L190-R190) [[3]](diffhunk://#diff-19160bb6e9fb98b3aa289c169095fe3ea65f8d7037fd82f33fdca2002cf45c43L199-R199)
* `cmd/create/create.go` and `cmd/list/list.go`: Updated calls to `GatherRepositories` to reflect the removal of error handling, simplifying the logic in `runCmdCreate` and `runCmdList`. [[1]](diffhunk://#diff-aaaad1429698979253f5f78e7d6a911d64bf99728415f0d90830d44a39e844e8L238-R238) [[2]](diffhunk://#diff-1f08e24d1678e1f9314edcedde3dad2a08ddc64ac6807c56543df3005d3ea205L218-R218)

### Ruleset processing improvement:
* [`internal/utils/exportruleset.go`](diffhunk://#diff-6ee93edff53264a925c97aedef0a7869739b0ca2e549e743e5e7a0c3760a5fbaR82-R86): Added a nil check for `RefName` conditions to prevent potential runtime errors when processing rulesets.