### PR TITLE
Topics/fix custom hostname create repo not exists

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -148,7 +148,7 @@ func runCmdCreate(owner string, cmdFlags *cmdFlags, g *utils.APIGetter, s *utils
 				}
 				zap.S().Infof("Successfully create repository ruleset %s for %s", ruleset.Name, owner)
 			} else if ruleset.SourceType == "Repository" {
-				zap.S().Debugf("Trying to create repository rulesets under %s/%s", owner, ruleset.Source)
+				zap.S().Debugf("Trying to create repository rulesets under %s", ruleset.Source)
 				exists := g.RepoExists(ruleset.Source)
 				if !exists {
 					zap.S().Debugf("Repository %s does not exist", ruleset.Source)

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -488,7 +488,7 @@ func (g *APIGetter) GetTeamByName(owner string, teamSlug string) (*data.TeamInfo
 
 func (g *APIGetter) RepoExists(ownerRepo string) bool {
 	url := fmt.Sprintf("repos/%s", ownerRepo)
-	zap.S().Debugf("Checking if repository %s exists", ownerRepo)
+	zap.S().Debugf("Checking if repository %s exists (%s)", ownerRepo, url)
 	resp, err := g.restClient.Request("GET", url, nil)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {


### PR DESCRIPTION
This pull request makes minor improvements to logging for repository-related operations, focusing on providing clearer and more informative debug messages.

Repository logging improvements:

* Updated the debug log in `runCmdCreate` (`cmd/create/create.go`) to only show the repository name when creating repository rulesets, removing the owner for clarity.
* Enhanced the debug log in `RepoExists` (`internal/utils/general.go`) to include both the repository name and the constructed URL, making it easier to trace API calls.