### PR TITLE
Change divider from '|' to '#|#'

### DIFF
--- a/internal/utils/exportruleset.go
+++ b/internal/utils/exportruleset.go
@@ -101,7 +101,7 @@ func ProcessProperties(properties []data.PropertyPattern) []string {
 		propertyList := []string{
 			property.Name,
 			property.Source,
-			fmt.Sprintf("{%s}", strings.Join(property.PropertyValues, "|")),
+			fmt.Sprintf("{%s}", strings.Join(property.PropertyValues, "#|#")),
 		}
 		propertyStrings = append(propertyStrings, strings.Join(propertyList, ";"))
 	}
@@ -121,7 +121,7 @@ func (g *APIGetter) ProcessRules(rules []data.Rules) map[string]string {
 				formattedParams = append(formattedParams, fmt.Sprintf("%s:%v", key, value))
 			}
 			if len(formattedParams) > 0 {
-				rulesMap[rule.Type] = strings.Join(formattedParams, "|")
+				rulesMap[rule.Type] = strings.Join(formattedParams, "#|#")
 			}
 		}
 	}

--- a/internal/utils/importruleset.go
+++ b/internal/utils/importruleset.go
@@ -69,7 +69,7 @@ func parseConditions(conditions []string) *data.Conditions {
 }
 
 func parsePropertyPatterns(patternsStr string) []data.PropertyPattern {
-	patterns := SplitIgnoringBraces(patternsStr, "|")
+	patterns := SplitIgnoringBraces(patternsStr, "#|#")
 	propertyPatterns := make([]data.PropertyPattern, 0, len(patterns))
 	for _, pattern := range patterns {
 		patternData := strings.Split(pattern, ";")
@@ -80,7 +80,7 @@ func parsePropertyPatterns(patternsStr string) []data.PropertyPattern {
 		propertyPatterns = append(propertyPatterns, data.PropertyPattern{
 			Name:           patternData[0],
 			Source:         patternData[1],
-			PropertyValues: strings.Split(valueTrimmed, "|"),
+			PropertyValues: strings.Split(valueTrimmed, "#|#"),
 		})
 	}
 	return propertyPatterns


### PR DESCRIPTION
This pull request updates the serialization and parsing logic for property patterns and rule parameters in the ruleset import/export utilities. The main change is replacing the delimiter used to separate values from `|` to `#|#`, which helps avoid conflicts with values that may contain the pipe character.

**Delimiter update for property patterns and rule parameters:**

* [`internal/utils/exportruleset.go`](diffhunk://#diff-6ee93edff53264a925c97aedef0a7869739b0ca2e549e743e5e7a0c3760a5fbaL104-R104): Changed the delimiter for joining property values and formatted rule parameters from `|` to `#|#` in both `ProcessProperties` and `ProcessRules` functions to improve robustness. [[1]](diffhunk://#diff-6ee93edff53264a925c97aedef0a7869739b0ca2e549e743e5e7a0c3760a5fbaL104-R104) [[2]](diffhunk://#diff-6ee93edff53264a925c97aedef0a7869739b0ca2e549e743e5e7a0c3760a5fbaL124-R124)

**Parsing logic adjustments:**

* [`internal/utils/importruleset.go`](diffhunk://#diff-7295dc6c5c7cdfa09d19fa7f721b5bd2bf4e52a40109f9a9ff1d78d14471af5aL72-R72): Updated the parsing logic in `parsePropertyPatterns` to split property patterns and property values using the new `#|#` delimiter, ensuring consistency with the export format. [[1]](diffhunk://#diff-7295dc6c5c7cdfa09d19fa7f721b5bd2bf4e52a40109f9a9ff1d78d14471af5aL72-R72) [[2]](diffhunk://#diff-7295dc6c5c7cdfa09d19fa7f721b5bd2bf4e52a40109f9a9ff1d78d14471af5aL83-R83)