### PR TITLE
Topics/get role data

### DIFF
--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -451,6 +451,7 @@ func (g *APIGetter) GetTeamData(ownerID int, teamID int) (*data.TeamInfo, error)
 
 	resp, err := g.restClient.Request("GET", url, nil)
 	if err != nil {
+		zap.S().Error("Error raised in getting team data", zap.Error(err))
 		return nil, err
 	}
 	defer func() {

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -449,7 +449,10 @@ func (g *APIGetter) GetRepoRulesetsList(owner string, repo string, endCursor *st
 func (g *APIGetter) GetTeamData(ownerID int, teamID int) (*data.TeamInfo, error) {
 	url := fmt.Sprintf("organizations/%s/team/%s", strconv.Itoa(ownerID), strconv.Itoa(teamID))
 
-	resp, _ := g.restClient.Request("GET", url, nil)
+	resp, err := g.restClient.Request("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			zap.S().Errorf("Error closing response body: %v", err)


### PR DESCRIPTION
This pull request introduces improved error handling to the `GetTeamData` method in `internal/utils/general.go`. The main change ensures that errors returned from the REST client are properly logged and propagated, which helps prevent silent failures and makes debugging easier.

Error handling improvements:

* Updated the `GetTeamData` function to check for errors from `g.restClient.Request`, log them using `zap.S().Error`, and return the error instead of ignoring it.